### PR TITLE
Added filtering for test files & Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,53 @@
 [![JetBrains Research](https://jb.gg/badges/research.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 
 # Code Change Miner
+
 A tool for mining graph-based change patterns in Python code.
 
 ## What it does
-A **program dependence graph** is a way of representing the code by showing its data dependencies and control 
+
+A **program dependence graph** is a way of representing the code by showing its data dependencies and control
 dependencies.
 
-A **change graph** is a program dependence graph for the fragment of code changes (using the versions of code before 
-and after the target change).
+A **change graph** is a program dependence graph for the fragment of code changes (using the versions of code before and
+after the target change).
 
-Similar code changes will have similar change graphs, which means that any versioned code can be mined for **patterns** 
-in its changes. This tool does exactly that for Python code: it can build program dependence graphs, build change graphs 
-for changed files, mine such change graphs from Git repositories by traversing their VCS history, and discover patterns 
+Similar code changes will have similar change graphs, which means that any versioned code can be mined for **patterns**
+in its changes. This tool does exactly that for Python code: it can build program dependence graphs, build change graphs
+for changed files, mine such change graphs from Git repositories by traversing their VCS history, and discover patterns
 in these change graphs.
 
-This functionality can be used for empirical research of coding practices, as well as for mining the candidates for 
+This functionality can be used for empirical research of coding practices, as well as for mining the candidates for
 potential IDE inspections.
 
 ## Getting started
-0. The tool requires Python 3.8+ to run.
+
+0. The tool requires Python 3.8+ to run. We have also tested it only on Linux and macOS systems.
 1. Install the required dependencies:
 
     ```shell script
     pip3 install -r requirements.txt
     ```
 
-2. Create the settings file _settings.json_ based on 
-[_conf/settings.json.example_](https://github.com/JetBrains-Research/code-change-miner/blob/master/conf/settings.json.example) 
-and save it in the [same directory](https://github.com/JetBrains-Research/code-change-miner/tree/master/conf). 
-You can find the description of individual settings 
-in [_conf/help.md_](https://github.com/JetBrains-Research/code-change-miner/blob/master/conf/help.md).
+2. Create the settings file _settings.json_ based on
+   [_
+   conf/settings.json.example_](https://github.com/JetBrains-Research/code-change-miner/blob/master/conf/settings.json.example)
+   and save it in the [same directory](https://github.com/JetBrains-Research/code-change-miner/tree/master/conf). You
+   can find the description of individual settings in [_
+   conf/help.md_](https://github.com/JetBrains-Research/code-change-miner/blob/master/conf/help.md).
 
 
-3. If you want to use the tool for building change graphs or mining change graphs from the local repositories, you need 
-to setup [GumTree](https://github.com/GumTreeDiff/gumtree). You can use the compiled version of GumTree 
-(can be found in the [_external_](https://github.com/JetBrains-Research/code-change-miner/tree/master/external) 
-directory), it is slightly modified and uses environment variables `GUMTREE_PYTHON_BIN` 
-(python interpreter path for GumTree pyparser calls) and `GUMTREE_PYPARSER_PATH` (pyparser script path). 
-Set them, for instance, as follows: 
-
-     ```shell script
-     GUMTREE_PYTHON_BIN=python3
-     ```
-     ```shell script
-     GUMTREE_PYPARSER_PATH={project_dir}/external/pyparser.py
-     ```
+3. If you want to use the tool for building change graphs or mining change graphs from the local repositories, you need
+   to setup [GumTree](https://github.com/GumTreeDiff/gumtree). But you can use the compiled version of GumTree
+   (can be found in the [_external_](https://github.com/JetBrains-Research/code-change-miner/tree/master/external)
+   directory), it is slightly modified and uses environment variables `GUMTREE_PYTHON_BIN`
+   (python interpreter path for GumTree pyparser calls) and `GUMTREE_PYPARSER_PATH` (python parser script path). **They
+   are set up automatically.**
 
 ## How to use
+
 You can run any step of the pipeline by using the following simple command:
+
 ```shell script
 python3 main.py <mode> <args>
 ```
@@ -57,93 +56,96 @@ The tool currently supports four operation modes:
 
 1. `pfg` — build a program dependence graph from the Python source.
 
-    Arguments:
+   Arguments:
     - `-i` — a path to the source file.
-    - `-o` — a path to the output file. Two files will be created, a .dot file with a graph and a .pdf file 
-    with its visualization.
+    - `-o` — a path to the output file. Two files will be created, a .dot file with a graph and a .pdf file with its
+      visualization.
     - `--no-closure` — **(optional)** if passed, no closure will be built for the graph.
-    - `--show-deps` — **(optional)** if passed, edges with type _dep_ will be present in the graph, indicating 
-    the dependence of the vertices on each other.
+    - `--show-deps` — **(optional)** if passed, edges with type _dep_ will be present in the graph, indicating the
+      dependence of the vertices on each other.
     - `--hide-op-kinds` — **(optional)** if passed, the types of operations will be hidden in the graph.
     - `--show-data-keys` — **(optional)** if passed, IDs of the variables will be present in the graph.
-    
-    Typical use:
-    
+
+   Typical use:
+
     ```shell script
     python3 main.py pfg -i examples/src.py -o images/pfg.dot
     ```
-    
+
 2. `cg` — build a change graph from two source files (before and after change).
 
-    Arguments:
+   Arguments:
     - `-s` — a path to the source file before changes.
     - `-d` — a path to the source file after changes.
-    - `-o` — a path to the output file. Two files will be created, a .dot file with a graph and 
-    a .pdf file with its visualization.
-    
-    Typical use:
-    
+    - `-o` — a path to the output file. Two files will be created, a .dot file with a graph and a .pdf file with its
+      visualization.
+
+   Typical use:
+
     ```shell script
     python3 main.py cg -s examples/0_old.py -d examples/0_new.py -o images/cg.dot
     ```
-    
+
 3. `collect-cgs` — mine change graphs from local repositories.
 
-    This mode takes no arguments, all the settings are located in the JSON file, see p. 3 of **Getting started**.
-    
-    Use:
-    
+   All the general settings for this mode are located in the JSON file, see p. 3 of **Getting started**.
+
+   Use:
+
     ```shell script
-    python3 main.py collect-cgs
+    python3 main.py collect-cgs <args>
     ```
-    
-    The tool uses [pickle](https://docs.python.org/3/library/pickle.html) to save the data, so the output files 
-    are serialized and can be only processed by pickle. Running the tool in the `patterns` mode 
-    for detecting patterns within the mined change graphs will deserialize them automatically. 
-    
+
+   Arguments:
+    - `--only-tests` — **(optional)** if passed, the tool will build change graphs only for the files with filenames
+      containing "test" substring.
+
+   The tool uses [pickle](https://docs.python.org/3/library/pickle.html) to save the data, so the output files are
+   serialized and can be only processed by pickle. Running the tool in the `patterns` mode for detecting patterns within
+   the mined change graphs will deserialize them automatically.
+
 4. `patterns` — search for patterns in the change graphs.
 
-    This mode can be run in two ways: from the results of the previous step or from the source files. The settings 
-    are located in the JSON file, see p. 3 of **Getting started**. If you want to look for patterns in the change graphs 
-    obtained from running the tool in the `collect-sgs` mode, simply run:
-    
+   This mode can be run in two ways: from the results of the previous step or from the source files. The settings are
+   located in the JSON file, see p. 3 of **Getting started**. If you want to look for patterns in the change graphs
+   obtained from running the tool in the `collect-sgs` mode, simply run:
+
     ```shell script
     python3 main.py patterns
     ```
-    and the tool will find the input automatically. Alternatively, you can mine patterns directly from files 
-    with the following arguments:
+   and the tool will find the input automatically. Alternatively, you can mine patterns directly from files with the
+   following arguments:
 
     - `-s` — a path to the source files before changes.
     - `-d` — a path to the source files after changes.
-    - `--fake-mining` — **(optional)** if passed, no mining is carried out, the change graphs as a whole 
-    are considered to be the patterns (used in debug).
-    
-    Typical use:
-    
+    - `--fake-mining` — **(optional)** if passed, no mining is carried out, the change graphs as a whole are considered
+      to be the patterns (used in debug).
+
+   Typical use:
+
     ```shell script
     python3 main.py patterns -s examples/0_old.py examples/1_old.py -d examples/0_new.py examples/1_new.py
     ```
-    
-    Here, the files are automatically mapped (_0_old.py_ -> _0_new.py_, _1_old.py_ -> _1_new.py_), their change graphs 
-    are built, and the patterns between them are mined. 
-    
-    In both usage scenarios, the `patterns` mode will produce results as shown in the picture below:
-    
+
+   Here, the files are automatically mapped (_0_old.py_ -> _0_new.py_, _1_old.py_ -> _1_new.py_), their change graphs
+   are built, and the patterns between them are mined.
+
+   In both usage scenarios, the `patterns` mode will produce results as shown in the picture below:
+
     <img src="https://sun9-47.userapi.com/c857320/v857320810/1b19c7/Sr42Lt0TfMU.jpg" alt="drawing" width="300"/>
-    
-    The patterns are organized by their size in nodes. In the output directory, a directory is created for each size, 
-    in the example, the size is 17. In each of these directories we store the patterns, once again, as directories 
-    with their ID in the name. In the example, 1379 is the ID of a pattern with size 17.
-    
-    Within each pattern, we store _details.html_ with its description and the listing of the pattern instances, 
-    and the instances themselves. For each instance, there are three types of files: _sample{ID}_ is 
-    the code of the instance (before and after the change), _fragment{ID}_ is the change graph of this specific sample, 
-    and _graph{ID}_ is the larger change graph, from which this sample came from. You can also control 
-    the specifics of the output by changing the settings file. _contents.html_ on every level of the structure provides
-    a convenient navigation. To understand the structure better, you can browse an example 
-    output in _survey_patterns.tar.gz_.
-    
+
+   The patterns are organized by their size in nodes. In the output directory, a directory is created for each size, in
+   the example, the size is 17. In each of these directories we store the patterns, once again, as directories with
+   their ID in the name. In the example, 1379 is the ID of a pattern with size 17.
+
+   Within each pattern, we store _details.html_ with its description and the listing of the pattern instances, and the
+   instances themselves. For each instance, there are three types of files: _sample{ID}_ is the code of the instance (
+   before and after the change), _fragment{ID}_ is the change graph of this specific sample, and _graph{ID}_ is the
+   larger change graph, from which this sample came from. You can also control the specifics of the output by changing
+   the settings file. _contents.html_ on every level of the structure provides a convenient navigation. To understand
+   the structure better, you can browse an example output in _survey_patterns.tar.gz_.
+
 ## Contacts
-    
-If you have any questions or suggestions, don't hesitate to open an issue or contact the developers 
-at stardust.skg@gmail.com.
+
+If you have any questions or suggestions, don't hesitate to open an issue or contact the developers at
+stardust.skg@gmail.com.

--- a/collect_cgs_from_tests.py
+++ b/collect_cgs_from_tests.py
@@ -1,0 +1,117 @@
+import argparse
+import os
+import pickle
+import tempfile
+import uuid
+from pathlib import Path
+from typing import List
+
+import changegraph
+import settings
+from changegraph.models import ChangeGraph
+from log import logger
+from vcs.traverse import GitAnalyzer, RepoInfo
+
+STORAGE_DIR = settings.get('change_graphs_storage_dir')
+
+
+def store_change_graphs(change_graphs: List[ChangeGraph]):
+    pickled_graphs = []
+    for graph in change_graphs:
+        try:
+            pickled = pickle.dumps(graph, protocol=5)
+            pickled_graphs.append(pickled)
+        except RecursionError:
+            logger.error(f'Unable to pickle graph {graph}')
+    filename = uuid.uuid4().hex
+    logger.info(f'Trying to store graphs to {filename}', show_pid=True)
+    with open(os.path.join(STORAGE_DIR, f'{filename}.pickle'), 'w+b') as f:
+        pickle.dump(pickled_graphs, f)
+    logger.info(f'Storing graphs to {filename} finished', show_pid=True)
+
+
+def main(src_dir: str):
+    change_graphs = []
+
+    try:
+
+        for dirname, _, files in os.walk(src_dir):
+            before_path, after_path = None, None
+            for filename in files:
+                if filename.endswith('.before.py'):
+                    before_path = os.path.join(dirname, filename)
+                elif filename.endswith('.after.py'):
+                    after_path = os.path.join(dirname, filename)
+
+            if before_path and after_path:
+                with open(before_path, 'r') as before_file, open(after_path, 'r') as after_file:
+                    before_src = before_file.read()
+                    after_src = after_file.read()
+
+                old_method_to_new = GitAnalyzer._get_methods_mapping(
+                    GitAnalyzer._extract_methods(before_path, before_src),
+                    GitAnalyzer._extract_methods(after_path, after_src)
+                )
+
+                for old_method, new_method in old_method_to_new.items():
+                    old_method_src = old_method.get_source()
+                    new_method_src = new_method.get_source()
+
+                    if not all([old_method_src, new_method_src]) or old_method_src.strip() == new_method_src.strip():
+                        continue
+
+                    line_count = max(old_method_src.count('\n'), new_method_src.count('\n'))
+                    if line_count > settings.get('traverse_file_max_line_count'):
+                        logger.info(f'Ignored files due to line limit: {before_path}')
+                        continue
+
+                    with tempfile.NamedTemporaryFile(mode='w+t', suffix='.py') as t1, \
+                            tempfile.NamedTemporaryFile(mode='w+t', suffix='.py') as t2:
+
+                        t1.writelines(old_method_src)
+                        t1.seek(0)
+                        t2.writelines(new_method_src)
+                        t2.seek(0)
+
+                        repo_info = RepoInfo(
+                            Path(dirname).parent.name,
+                            dirname,
+                            '',
+                            '',
+                            '',
+                            before_path,
+                            after_path,
+                            old_method,
+                            new_method
+                        )
+
+                        try:
+                            cg = changegraph.build_from_files(os.path.realpath(t1.name), os.path.realpath(t2.name),
+                                                              repo_info=repo_info)
+                        except:
+                            logger.log(logger.ERROR,
+                                       f'Unable to build a change graph for '
+                                       f'method={old_method.full_name}, '
+                                       f'line={old_method.ast.lineno}', exc_info=True, show_pid=True)
+                            continue
+
+                        change_graphs.append(cg)
+
+                        if len(change_graphs) >= GitAnalyzer.STORE_INTERVAL:
+                            store_change_graphs(change_graphs)
+                            change_graphs.clear()
+
+    except KeyboardInterrupt:
+        logger.info('KeyboardInterrupt: change-graphs will be stored before exit')
+
+    if change_graphs:
+        GitAnalyzer._store_change_graphs(change_graphs)
+        change_graphs.clear()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--src', help='Path to directory with before and after versions', type=str, required=True)
+    args = parser.parse_args()
+
+    main(args.src)

--- a/collect_cgs_from_tests.py
+++ b/collect_cgs_from_tests.py
@@ -1,6 +1,8 @@
 import argparse
+import multiprocessing
 import os
 import pickle
+import sys
 import tempfile
 import uuid
 from pathlib import Path
@@ -9,6 +11,7 @@ from typing import List
 import changegraph
 import settings
 from changegraph.models import ChangeGraph
+from deployment import set_all_environment_variables
 from log import logger
 from vcs.traverse import GitAnalyzer, RepoInfo
 
@@ -110,6 +113,10 @@ def main(src_dir: str):
 
 
 if __name__ == '__main__':
+    set_all_environment_variables()
+    sys.setrecursionlimit(2 ** 31 - 1)
+    multiprocessing.set_start_method('spawn', force=True)
+
     parser = argparse.ArgumentParser()
     parser.add_argument('-s', '--src', help='Path to directory with before and after versions', type=str, required=True)
     args = parser.parse_args()

--- a/deployment.py
+++ b/deployment.py
@@ -1,19 +1,17 @@
 import os
 
-
 PROJECT_DIRECTORY = os.path.dirname(__file__)
+PYTHON_BIN_ENV_VAR = "GUMTREE_PYTHON_BIN"
+PYPARSER_ENV_VAR = "GUMTREE_PYPARSER_PATH"
 
 
 def set_environment_variable(env_var, value):
-    if os.getenv(env_var) is None:
-        os.environ[env_var] = value
+    os.environ[env_var] = value
 
 
 def set_all_environment_variables():
-    PYTHON_BIN_ENV_VAR = "GUMTREE_PYTHON_BIN"
     PYTHON_BIN_VALUE = "python3"
     set_environment_variable(PYTHON_BIN_ENV_VAR, PYTHON_BIN_VALUE)
 
-    PYPARSER_ENV_VAR = "GUMTREE_PYPARSER_PATH"
     pyparser_path = os.path.join(PROJECT_DIRECTORY, 'external', 'pythonparser_3.py')
     set_environment_variable(PYPARSER_ENV_VAR, pyparser_path)

--- a/deployment.py
+++ b/deployment.py
@@ -1,8 +1,12 @@
 import os
 
 PROJECT_DIRECTORY = os.path.dirname(__file__)
+
 PYTHON_BIN_ENV_VAR = "GUMTREE_PYTHON_BIN"
 PYPARSER_ENV_VAR = "GUMTREE_PYPARSER_PATH"
+
+PYTHON_BIN_VALUE = "python3"
+PYPARSER_NAME = 'pythonparser_3.py'
 
 
 def set_environment_variable(env_var, value):
@@ -10,8 +14,7 @@ def set_environment_variable(env_var, value):
 
 
 def set_all_environment_variables():
-    PYTHON_BIN_VALUE = "python3"
     set_environment_variable(PYTHON_BIN_ENV_VAR, PYTHON_BIN_VALUE)
 
-    pyparser_path = os.path.join(PROJECT_DIRECTORY, 'external', 'pythonparser_3.py')
+    pyparser_path = os.path.join(PROJECT_DIRECTORY, 'external', PYPARSER_NAME)
     set_environment_variable(PYPARSER_ENV_VAR, pyparser_path)

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def main():
             app_version=str(datetime.datetime.now())
         )
 
-    sys.setrecursionlimit(2**31-1)
+    sys.setrecursionlimit(2 ** 31 - 1)
     multiprocessing.set_start_method('spawn', force=True)
 
     parser = argparse.ArgumentParser()
@@ -68,7 +68,12 @@ def main():
         fg = changegraph.build_from_files(args.src, args.dest)
         changegraph.export_graph_image(fg, args.output)
     elif current_mode == RunModes.COLLECT_CHANGE_GRAPHS:
-        GitAnalyzer().build_change_graphs()
+        parser.add_argument('--only-tests',
+                            help='Collect cgs only for the files with "test" substring in the name',
+                            action='store_true')
+        args = parser.parse_args()
+
+        GitAnalyzer().build_change_graphs(args.only_tests)
     elif current_mode == RunModes.MINE_PATTERNS:
         parser.add_argument('-s', '--src', help='Path to source code before changes', type=str, nargs='+')
         parser.add_argument('-d', '--dest', help='Path to source code after changes', type=str, nargs='+')
@@ -125,7 +130,7 @@ def main():
                     logger.warning(f'Incorrect file {file_path}')
 
                 if file_num % 1000 == 0:
-                    logger.warning(f'Loaded [{1+file_num}/{len(file_names)}] files')
+                    logger.warning(f'Loaded [{1 + file_num}/{len(file_names)}] files')
             logger.warning('Pattern mining has started')
 
             miner = Miner()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 graphviz==0.13.2
-asttokens==2.0.3
+asttokens==2.0.4
 pydriller==1.12
 
 pytest==5.3.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from deployment import set_all_environment_variables
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prepare_for_tests():
+    set_all_environment_variables()

--- a/tests/test_change_graphs.py
+++ b/tests/test_change_graphs.py
@@ -1,8 +1,7 @@
-import tempfile
 import os
+import tempfile
 
 import changegraph
-from deployment import set_all_environment_variables
 import tests.utils as utils
 from log import logger
 
@@ -415,8 +414,6 @@ def test_complex_example10():
 
 
 if __name__ == '__main__':
-    set_all_environment_variables()
-
     test_complex_example10()
     test_complex_example9()
     test_complex_example8()

--- a/vcs/traverse.py
+++ b/vcs/traverse.py
@@ -8,6 +8,7 @@ import time
 import json
 import subprocess
 import datetime
+from functools import partial
 
 from log import logger
 from pydriller import RepositoryMining
@@ -81,7 +82,7 @@ class GitAnalyzer:
 
             if pool and len(commits) > 0:
                 try:
-                    pool.map(lambda commit: self._build_and_store_change_graphs(commit, parse_only_tests), commits)
+                    pool.starmap(self._build_and_store_change_graphs, zip(commits, [parse_only_tests] * len(commits)))
                 except:
                     logger.error(f'Pool.map failed for repo {repo_name}', exc_info=True)
             else:

--- a/vcs/traverse.py
+++ b/vcs/traverse.py
@@ -111,7 +111,7 @@ class GitAnalyzer:
                     'email': commit.author.email,
                     'name': commit.author.name
                 } if commit.author else None,
-                'num': len(commits)+1,
+                'num': len(commits) + 1,
                 'hash': commit.hash,
                 'dtm': commit.committer_date,
                 'msg': commit.msg,
@@ -174,6 +174,12 @@ class GitAnalyzer:
 
             if not all([mod['old_path'].endswith('.py'), mod['new_path'].endswith('.py')]):
                 continue
+
+            # Skip if file's name does not contain `test`
+            if mod['old_path'].find('test') == -1 and mod['new_path'].find('test') == -1:
+                continue
+
+            print(mod['old_path'])
 
             old_method_to_new = GitAnalyzer._get_methods_mapping(
                 GitAnalyzer._extract_methods(mod['old_path'], mod['old_src']),

--- a/vcs/traverse.py
+++ b/vcs/traverse.py
@@ -52,7 +52,7 @@ class GitAnalyzer:
         with open(self._data_file_dir, 'w+') as f:
             json.dump(self._data, f, indent=4)
 
-    def build_change_graphs(self):
+    def build_change_graphs(self, parse_only_tests=False):
         repo_names = [
             name for name in os.listdir(self.GIT_REPOSITORIES_DIR)
             if not name.startswith('_') and not name.startswith('.') and name not in self._data['visited']]
@@ -65,11 +65,11 @@ class GitAnalyzer:
 
         if GitAnalyzer.TRAVERSE_ASYNC:
             with multiprocessing.Pool(processes=multiprocessing.cpu_count(), maxtasksperchild=1000) as pool:
-                self._mine_changes(repo_names, pool=pool)
+                self._mine_changes(repo_names, pool=pool, parse_only_tests=parse_only_tests)
         else:
-            self._mine_changes(repo_names)
+            self._mine_changes(repo_names, parse_only_tests=parse_only_tests)
 
-    def _mine_changes(self, repo_names, pool=None):
+    def _mine_changes(self, repo_names, pool=None, parse_only_tests=False):
         for repo_num, repo_name in enumerate(repo_names):
             logger.warning(f'Looking at repo {repo_name} [{repo_num + 1}/{len(repo_names)}]')
 
@@ -81,12 +81,12 @@ class GitAnalyzer:
 
             if pool and len(commits) > 0:
                 try:
-                    pool.map(self._build_and_store_change_graphs, commits)
+                    pool.map(lambda commit: self._build_and_store_change_graphs(commit, parse_only_tests), commits)
                 except:
                     logger.error(f'Pool.map failed for repo {repo_name}', exc_info=True)
             else:
                 for commit in commits:
-                    self._build_and_store_change_graphs(commit)
+                    self._build_and_store_change_graphs(commit, parse_only_tests)
 
             logger.warning(f'Done building change graphs for repo={repo_name} [{repo_num + 1}/{len(repo_names)}]',
                            start_time=start)
@@ -163,7 +163,7 @@ class GitAnalyzer:
         logger.info(f'Storing graphs to {filename} finished', show_pid=True)
 
     @staticmethod
-    def _build_and_store_change_graphs(commit):
+    def _build_and_store_change_graphs(commit, parse_only_tests=False):
         change_graphs = []
         commit_msg = commit['msg'].replace('\n', '; ')
         logger.info(f'Looking at commit #{commit["hash"]}, msg: "{commit_msg}"', show_pid=True)
@@ -175,11 +175,9 @@ class GitAnalyzer:
             if not all([mod['old_path'].endswith('.py'), mod['new_path'].endswith('.py')]):
                 continue
 
-            # Skip if file's name does not contain `test`
-            if mod['old_path'].find('test') == -1 and mod['new_path'].find('test') == -1:
-                continue
-
-            print(mod['old_path'])
+            if parse_only_tests:
+                if mod['old_path'].find('test') == -1 and mod['new_path'].find('test') == -1:
+                    continue
 
             old_method_to_new = GitAnalyzer._get_methods_mapping(
                 GitAnalyzer._extract_methods(mod['old_path'], mod['old_src']),


### PR DESCRIPTION
- Added flag `--only-tests` for `collect-cgs` mode to mine change graphs only from the test files during traversing repositories;
- Added `collect_cgs_from_tests.py` script to mine change graphs from preprocessed "before" and "after" files (for internal use cases);
- Fixed environment variables setup & added fixture to set them for all tests in `conftest.py`;
- Fixed `asttokens` version, now it is `2.0.4` instead of `2.0.3`
- Adjusted README. 